### PR TITLE
Re-instate person Tenure details

### DIFF
--- a/Hackney.Shared.Person.Tests/Boundary/Validation/TenureValidatorTests.cs
+++ b/Hackney.Shared.Person.Tests/Boundary/Validation/TenureValidatorTests.cs
@@ -1,0 +1,100 @@
+﻿using FluentValidation.TestHelper;
+using Hackney.Shared.Person.Boundary.Request.Validation;
+using Hackney.Shared.Person.Domain;
+using System;
+using Xunit;
+
+namespace Hackney.Shared.Person.Tests.Boundary.Validation
+{
+    public class TenureValidatorTests
+    {
+        private readonly TenureValidator _sut;
+
+        public TenureValidatorTests()
+        {
+            _sut = new TenureValidator();
+        }
+
+        [Theory]
+        [InlineData("10 Some month 2001")]
+        public void StartDateShouldErrorWithInvalidValue(string invalid)
+        {
+            var model = new TenureDetails() { StartDate = invalid };
+            var result = _sut.TestValidate(model);
+            result.ShouldHaveValidationErrorFor(x => x.StartDate);
+        }
+
+        [Theory]
+        [InlineData("10 Some month 2001")]
+        public void EndDateShouldErrorWithInvalidValue(string invalid)
+        {
+            var model = new TenureDetails() { EndDate = invalid };
+            var result = _sut.TestValidate(model);
+            result.ShouldHaveValidationErrorFor(x => x.EndDate);
+        }
+
+        [Fact]
+        public void ShouldErrorWithEmptyId()
+        {
+            var query = new TenureDetails() { Id = Guid.Empty };
+            var result = _sut.TestValidate(query);
+            result.ShouldHaveValidationErrorFor(x => x.Id);
+        }
+
+        [Fact]
+        public void PropertiesShouldErrorWithTagsInValue()
+        {
+            string value = "Some string with <tag> in it.";
+            var model = new TenureDetails()
+            {
+                AssetFullAddress = value,
+                AssetId = value,
+                Type = value,
+                PropertyReference = value,
+                PaymentReference = value,
+                Uprn = value
+            };
+            var result = _sut.TestValidate(model);
+            result.ShouldHaveValidationErrorFor(x => x.AssetFullAddress)
+                  .WithErrorCode(ErrorCodes.XssCheckFailure);
+            result.ShouldHaveValidationErrorFor(x => x.AssetId)
+                  .WithErrorCode(ErrorCodes.XssCheckFailure);
+            result.ShouldHaveValidationErrorFor(x => x.Type)
+                  .WithErrorCode(ErrorCodes.XssCheckFailure);
+            result.ShouldHaveValidationErrorFor(x => x.PropertyReference)
+                  .WithErrorCode(ErrorCodes.XssCheckFailure);
+            result.ShouldHaveValidationErrorFor(x => x.PaymentReference)
+                  .WithErrorCode(ErrorCodes.XssCheckFailure);
+            result.ShouldHaveValidationErrorFor(x => x.Uprn)
+                  .WithErrorCode(ErrorCodes.XssCheckFailure);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void PropertiesShouldNotErrorWithNoValue(string value)
+        {
+            var model = new TenureDetails()
+            {
+                AssetFullAddress = value,
+                AssetId = value,
+                StartDate = value,
+                EndDate = value,
+                Type = value,
+                PropertyReference = value,
+                PaymentReference = value,
+                Uprn = value
+            };
+            var result = _sut.TestValidate(model);
+
+            result.ShouldNotHaveValidationErrorFor(x => x.AssetFullAddress);
+            result.ShouldNotHaveValidationErrorFor(x => x.AssetId);
+            result.ShouldNotHaveValidationErrorFor(x => x.StartDate);
+            result.ShouldNotHaveValidationErrorFor(x => x.EndDate);
+            result.ShouldNotHaveValidationErrorFor(x => x.Type);
+            result.ShouldNotHaveValidationErrorFor(x => x.PropertyReference);
+            result.ShouldNotHaveValidationErrorFor(x => x.PaymentReference);
+            result.ShouldNotHaveValidationErrorFor(x => x.Uprn);
+        }
+    }
+}

--- a/Hackney.Shared.Person.Tests/Domain/PersonTests.cs
+++ b/Hackney.Shared.Person.Tests/Domain/PersonTests.cs
@@ -1,10 +1,9 @@
 using FluentAssertions;
 using Hackney.Shared.Person.Tests.Helper;
-using Hackney.Shared.Person;
 using System.Linq;
 using Xunit;
 
-namespace Hackney.Shared.Person.Tests
+namespace Hackney.Shared.Person.Tests.Domain
 {
     public class PersonTests
     {
@@ -27,9 +26,14 @@ namespace Hackney.Shared.Person.Tests
             person.PersonTypes.Should().BeEquivalentTo(Constants.PERSONTYPES);
             person.Tenures.Should().ContainSingle();
             person.Tenures.First().Id.Should().Be(Constants.TENUREID);
-            person.Tenures.First().TenuredAsset.Id.Should().Be(Constants.ASSETID);
-            person.Tenures.First().TenuredAsset.FullAddress.Should().Be(Constants.ASSETFULLADDRESS);
-            person.Tenures.First().TenuredAsset.Type.Should().Be(Constants.SOMETYPE);
+            person.Tenures.First().AssetId.Should().Be(Constants.ASSETID.ToString());
+            person.Tenures.First().AssetFullAddress.Should().Be(Constants.ASSETFULLADDRESS);
+            person.Tenures.First().StartDate.Should().Be(Constants.STARTDATE);
+            person.Tenures.First().EndDate.Should().Be(Constants.ENDDATE);
+            person.Tenures.First().Type.Should().Be(Constants.SOMETYPE);
+            person.Tenures.First().PaymentReference.Should().Be(Constants.PAYMENTREF);
+            person.Tenures.First().PropertyReference.Should().Be(Constants.PROPERTYREF);
+            person.Tenures.First().Uprn.Should().Be(Constants.SOMEUPRN);
         }
     }
 }

--- a/Hackney.Shared.Person.Tests/Domain/TenureTests.cs
+++ b/Hackney.Shared.Person.Tests/Domain/TenureTests.cs
@@ -1,0 +1,115 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using Force.DeepCloner;
+using Hackney.Shared.Person.Domain;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Hackney.Shared.Person.Tests.Domain
+{
+    public class TenureTests
+    {
+        private readonly Fixture _fixture = new Fixture();
+        private TenureDetails _classUnderTest;
+
+        public TenureTests()
+        {
+            _classUnderTest = new Shared.Person.Domain.TenureDetails();
+        }
+
+        [Fact]
+        public void GivenATenureWhenEndDateIsNullThenIsActiveShouldBeTrue()
+        {
+            // given + when + then
+            _classUnderTest.IsActive.Should().BeTrue();
+        }
+
+        [Fact]
+        public void GivenATenureWhenEndDateIsGreaterThanCurrentDateThenIsActiveShouldBeTrue()
+        {
+            // given
+            _classUnderTest.EndDate = DateTime.Now.AddDays(1).ToShortDateString();
+
+            // when + then
+            _classUnderTest.IsActive.Should().BeTrue();
+        }
+
+        [Fact]
+        public void GivenATenureWhenEndDateIsMinimumDateThanCurrentDateThenIsActiveShouldBeTrue()
+        {
+            // given
+            _classUnderTest.EndDate = "1900-01-01";
+
+            // when + then
+            _classUnderTest.IsActive.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void GivenATenureWhenEndDateIsLessThanCurrentDateThenIsActiveShouldBeFalse(int daysToAdd)
+        {
+            // given
+            _classUnderTest.EndDate = DateTime.Now.AddDays(daysToAdd).ToShortDateString();
+
+            // when + then
+            _classUnderTest.IsActive.Should().BeFalse();
+        }
+
+        [Fact]
+        public void EqualsTestWrongTypeReturnsFalse()
+        {
+            _classUnderTest.Equals("some string").Should().BeFalse();
+        }
+
+        [Fact]
+        public void EqualsTestSameObjectReturnsTrue()
+        {
+            _classUnderTest = _fixture.Create<TenureDetails>();
+            _classUnderTest.Equals(_classUnderTest).Should().BeTrue();
+        }
+
+        [Fact]
+        public void EqualsTestEquivalentObjectReturnsTrue()
+        {
+            _classUnderTest = _fixture.Create<TenureDetails>();
+            var compare = _classUnderTest.DeepClone();
+            _classUnderTest.Equals(compare).Should().BeTrue();
+        }
+
+        [Fact]
+        public void EqualsTestDifferentObjectReturnsFalse()
+        {
+            _classUnderTest = _fixture.Create<TenureDetails>();
+            var compare = _fixture.Create<TenureDetails>();
+            _classUnderTest.Equals(compare).Should().BeFalse();
+        }
+
+        [Fact]
+        public void EqualsTestNullObjectReturnsFalse()
+        {
+            _classUnderTest = _fixture.Create<TenureDetails>();
+            _classUnderTest.Equals(null).Should().BeFalse();
+        }
+
+        [Fact]
+        public void EqualsTestWithNullsEquivalentObjectReturnsTrue()
+        {
+            _classUnderTest = new TenureDetails();
+            var compare = new TenureDetails();
+            _classUnderTest.Equals(compare).Should().BeTrue();
+        }
+
+        [Fact]
+        public void GetHashCodeTest()
+        {
+            _classUnderTest = _fixture.Create<TenureDetails>();
+            var propValues = _classUnderTest.GetType()
+                                .GetProperties()
+                                .Select(x => x.GetValue(_classUnderTest).ToString());
+            var expected = string.Join("", propValues).GetHashCode();
+            _classUnderTest.GetHashCode().Should().Be(expected);
+        }
+    }
+}

--- a/Hackney.Shared.Person.Tests/Factories/ResponseFactoryTest.cs
+++ b/Hackney.Shared.Person.Tests/Factories/ResponseFactoryTest.cs
@@ -20,8 +20,8 @@ namespace Hackney.Shared.Person.Tests.Factories
 
         private readonly Random _random = new Random();
 
-        private readonly DateTime? _activeTenureDateValue = null;
-        private readonly DateTime? _inactiveTeunureDateValue = DateTime.UtcNow.AddDays(-7); // generate date in past
+        private readonly string _activeTenureDateValue = null;
+        private readonly string _inactiveTeunureDateValue = DateTime.UtcNow.AddDays(-7).ToString(); // generate date in past
 
 
         public ResponseFactoryTest()
@@ -82,9 +82,9 @@ namespace Hackney.Shared.Person.Tests.Factories
             var numberOfInactiveTenures = _random.Next(2, 5);
 
             // create many active tenures
-            var activeTenures = _fixture.Build<TenureInformation>().With(x => x.EndOfTenureDate, _activeTenureDateValue).CreateMany(numberOfActiveTenures);
+            var activeTenures = _fixture.Build<TenureDetails>().With(x => x.EndDate, _activeTenureDateValue).CreateMany(numberOfActiveTenures);
             // create many inactive tenures
-            var inactiveTenures = _fixture.Build<TenureInformation>().With(x => x.EndOfTenureDate, _inactiveTeunureDateValue).CreateMany(numberOfInactiveTenures);
+            var inactiveTenures = _fixture.Build<TenureDetails>().With(x => x.EndDate, _inactiveTeunureDateValue).CreateMany(numberOfInactiveTenures);
 
             // shuffle list
             var shuffledTenures = ShuffleTenures(activeTenures.Concat(inactiveTenures));
@@ -116,10 +116,10 @@ namespace Hackney.Shared.Person.Tests.Factories
             var numberOfOtherTenureTypes = _random.Next(2, 5);
 
             // create many secure tenures
-            var secureTenures = _fixture.Build<TenureInformation>().With(x => x.EndOfTenureDate, tenureEndDate).With(x => x.TenureType, TenureTypes.Secure).CreateMany(numberOfSecureTenures);
+            var secureTenures = _fixture.Build<TenureDetails>().With(x => x.EndDate, tenureEndDate).With(x => x.Type, "Secure").CreateMany(numberOfSecureTenures);
 
             // create many tenures of other types
-            var otherTenureTypes = _fixture.Build<TenureInformation>().With(x => x.EndOfTenureDate, tenureEndDate).CreateMany(numberOfOtherTenureTypes);
+            var otherTenureTypes = _fixture.Build<TenureDetails>().With(x => x.EndDate, tenureEndDate).CreateMany(numberOfOtherTenureTypes);
 
             // shuffle list
             var shuffledTenures = ShuffleTenures(secureTenures.Concat(otherTenureTypes));
@@ -134,10 +134,10 @@ namespace Hackney.Shared.Person.Tests.Factories
             var responseOtherTenureTypes = response.Tenures.Skip(numberOfSecureTenures).Take(numberOfOtherTenureTypes);
 
             // assert first half are secure
-            responseSecureTenures.Should().OnlyContain(x => x.TenureType.Description == "Secure");
+            responseSecureTenures.Should().OnlyContain(x => x.Type == "Secure");
 
             // assert second half arent secure
-            responseOtherTenureTypes.Should().NotContain(x => x.TenureType.Description == "Secure");
+            responseOtherTenureTypes.Should().NotContain(x => x.Type == "Secure");
         }
 
         [Theory]
@@ -151,17 +151,17 @@ namespace Hackney.Shared.Person.Tests.Factories
             var numberOfOtherTenureTypes = _random.Next(5, 10);
 
             // create many secure tenures
-            var secureTenures = _fixture.Build<TenureInformation>()
-                .With(x => x.EndOfTenureDate, tenureEndDate)
-                .With(x => x.TenureType, TenureTypes.Secure)
-                .With(x => x.StartOfTenureDate, CreateRandomStartDateValue())
+            var secureTenures = _fixture.Build<TenureDetails>()
+                .With(x => x.EndDate, tenureEndDate)
+                .With(x => x.Type, "Secure")
+                .With(x => x.StartDate, CreateRandomStartDateValue)
                 .CreateMany(numberOfSecureTenures);
 
             // create many tenures of other types
             var otherTenureTypes = _fixture
-                .Build<TenureInformation>()
-                .With(x => x.EndOfTenureDate, tenureEndDate)
-                .With(x => x.StartOfTenureDate, CreateRandomStartDateValue())
+                .Build<TenureDetails>()
+                .With(x => x.EndDate, tenureEndDate)
+                .With(x => x.StartDate, CreateRandomStartDateValue)
                 .CreateMany(numberOfOtherTenureTypes);
 
             // shuffle list
@@ -177,23 +177,23 @@ namespace Hackney.Shared.Person.Tests.Factories
             var responseOtherTenureTypes = response.Tenures.Skip(numberOfSecureTenures).Take(numberOfOtherTenureTypes);
 
             // assert tenures tenures are in date order
-            responseSecureTenures.Select(x => x.StartOfTenureDate).Should().BeInDescendingOrder();
-            responseOtherTenureTypes.Select(x => x.StartOfTenureDate).Should().BeInDescendingOrder();
+            responseSecureTenures.Select(x => DateTime.Parse(x.StartDate)).Should().BeInDescendingOrder();
+            responseOtherTenureTypes.Select(x => DateTime.Parse(x.StartDate)).Should().BeInDescendingOrder();
         }
 
-        private IEnumerable<TenureInformation> ShuffleTenures(IEnumerable<TenureInformation> list)
+        private IEnumerable<TenureDetails> ShuffleTenures(IEnumerable<TenureDetails> list)
         {
             Random random = new Random();
 
             return list.OrderBy(item => random.Next());
         }
 
-        private DateTime CreateRandomStartDateValue()
+        private string CreateRandomStartDateValue()
         {
             // An inactive tenure must have enddate set in past
             var numberOfDaysInPast = _random.Next(-1000, -1);
 
-            return DateTime.UtcNow.AddDays(numberOfDaysInPast);
+            return DateTime.UtcNow.AddDays(numberOfDaysInPast).ToString();
         }
     }
 }

--- a/Hackney.Shared.Person.Tests/Hackney.Shared.Person.Tests.csproj
+++ b/Hackney.Shared.Person.Tests/Hackney.Shared.Person.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DeepCloner" Version="0.10.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/Hackney.Shared.Person.Tests/Helper/Constants.cs
+++ b/Hackney.Shared.Person.Tests/Helper/Constants.cs
@@ -1,7 +1,6 @@
 using Hackney.Shared.Person.Domain;
 using System;
 using System.Collections.Generic;
-using Hackney.Shared.Tenure.Domain;
 
 namespace Hackney.Shared.Person.Tests.Helper
 {
@@ -18,13 +17,16 @@ namespace Hackney.Shared.Person.Tests.Helper
         public const string SURNAME = "Roberts";
         public const string PLACEOFBIRTH = "London";
         public static DateTime DATEOFBIRTH { get; } = DateTime.UtcNow.AddYears(-40);
+
         public static Guid TENUREID = Guid.NewGuid();
         public const string SOMEUPRN = "SomeUprn";
-        public const TenuredAssetType SOMETYPE = TenuredAssetType.Block;
-        public static Guid ASSETID = Guid.NewGuid();
+        public const string SOMETYPE = "Block";
+        public static string ASSETID = Guid.NewGuid().ToString();
         public const string ASSETFULLADDRESS = "SomeAddress";
-        public static DateTime STARTDATE = Convert.ToDateTime("2012-07-19");
-        public static DateTime ENDDATE = Convert.ToDateTime("2015-07-19");
+        public const string STARTDATE = "2012-07-19";
+        public const string ENDDATE = "2015-07-19";
+        public const string PAYMENTREF = "123456789";
+        public const string PROPERTYREF = "987654321";
 
         public static IEnumerable<PersonType> PERSONTYPES { get; }
             = new List<PersonType> { PersonType.HouseholdMember };
@@ -45,18 +47,17 @@ namespace Hackney.Shared.Person.Tests.Helper
             entity.DateOfBirth = Constants.DATEOFBIRTH;
             entity.Tenures = new[]
             {
-                new TenureInformation
+                new Shared.Person.Domain.TenureDetails
                 {
+                    AssetFullAddress = ASSETFULLADDRESS,
+                    AssetId = ASSETID,
+                    EndDate = ENDDATE,
+                    StartDate = STARTDATE,
                     Id = TENUREID,
-                    StartOfTenureDate = STARTDATE,
-                    EndOfTenureDate = ENDDATE,
-                    TenuredAsset = new TenuredAsset
-                    {
-                        Id = ASSETID,
-                        Type = SOMETYPE,
-                        FullAddress = ASSETFULLADDRESS,
-                        Uprn = SOMEUPRN
-                    }
+                    Type = SOMETYPE,
+                    PaymentReference = PAYMENTREF,
+                    PropertyReference = PROPERTYREF,
+                    Uprn = SOMEUPRN
                 }
             };
             entity.PersonTypes = Constants.PERSONTYPES;

--- a/Hackney.Shared.Person/Boundary/Request/CreatePersonRequestObject.cs
+++ b/Hackney.Shared.Person/Boundary/Request/CreatePersonRequestObject.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Hackney.Shared.Person.Domain;
-using Hackney.Shared.Tenure.Domain;
 
 namespace Hackney.Shared.Person.Boundary.Request
 {
@@ -31,6 +30,6 @@ namespace Hackney.Shared.Person.Boundary.Request
 
         public string Reason { get; set; }
         public IEnumerable<PersonType> PersonTypes { get; set; }
-        public IEnumerable<TenureInformation> Tenures { get; set; }
+        public IEnumerable<TenureDetails> Tenures { get; set; }
     }
 }

--- a/Hackney.Shared.Person/Boundary/Request/UpdatePersonRequestObject.cs
+++ b/Hackney.Shared.Person/Boundary/Request/UpdatePersonRequestObject.cs
@@ -1,5 +1,4 @@
 using Hackney.Shared.Person.Domain;
-using Hackney.Shared.Tenure.Domain;
 using System;
 using System.Collections.Generic;
 
@@ -26,6 +25,6 @@ namespace Hackney.Shared.Person.Boundary.Request
         public string PlaceOfBirth { get; set; }
 
         public DateTime? DateOfBirth { get; set; }
-        public IEnumerable<TenureInformation> Tenures { get; set; }
+        public IEnumerable<TenureDetails> Tenures { get; set; }
     }
 }

--- a/Hackney.Shared.Person/Boundary/Request/Validation/CreatePersonRequestObjectValidator.cs
+++ b/Hackney.Shared.Person/Boundary/Request/Validation/CreatePersonRequestObjectValidator.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using Hackney.Core.Validation;
-using Hackney.Shared.Tenure.Boundary.Requests.Validation;
 using System;
 
 namespace Hackney.Shared.Person.Boundary.Request.Validation
@@ -65,7 +64,7 @@ namespace Hackney.Shared.Person.Boundary.Request.Validation
                 .NotXssString()
                 .WithErrorCode(ErrorCodes.XssCheckFailure)
                 .When(y => !string.IsNullOrEmpty(y.PlaceOfBirth));
-            RuleForEach(x => x.Tenures).SetValidator(new TenureInformationValidatorWhenOnlyEndDate());
+            RuleForEach(x => x.Tenures).SetValidator(new TenureValidator());
         }
     }
 }

--- a/Hackney.Shared.Person/Boundary/Request/Validation/TenureValidator.cs
+++ b/Hackney.Shared.Person/Boundary/Request/Validation/TenureValidator.cs
@@ -1,0 +1,43 @@
+﻿using FluentValidation;
+using Hackney.Core.Validation;
+using System;
+
+namespace Hackney.Shared.Person.Boundary.Request.Validation
+{
+    public class TenureValidator : AbstractValidator<Domain.TenureDetails>
+    {
+        public TenureValidator()
+        {
+            RuleFor(x => x.AssetFullAddress)
+                .NotXssString()
+                .WithErrorCode(ErrorCodes.XssCheckFailure)
+                .When(y => !string.IsNullOrEmpty(y.AssetFullAddress));
+            RuleFor(x => x.AssetId)
+                .NotXssString()
+                .WithErrorCode(ErrorCodes.XssCheckFailure)
+                .When(y => !string.IsNullOrEmpty(y.AssetId));
+            RuleFor(x => x.StartDate).Must(x => DateTime.TryParse(x, out DateTime dt))
+                .When(y => !string.IsNullOrEmpty(y.StartDate));
+            RuleFor(x => x.EndDate).Must(x => DateTime.TryParse(x, out DateTime dt))
+                .When(y => !string.IsNullOrEmpty(y.EndDate));
+            RuleFor(x => x.Id).NotNull()
+                              .NotEqual(Guid.Empty);
+            RuleFor(x => x.Type)
+                .NotXssString()
+                .WithErrorCode(ErrorCodes.XssCheckFailure)
+                .When(y => !string.IsNullOrEmpty(y.Type));
+            RuleFor(x => x.Uprn)
+                .NotXssString()
+                .WithErrorCode(ErrorCodes.XssCheckFailure)
+                .When(y => !string.IsNullOrEmpty(y.Uprn));
+            RuleFor(x => x.PropertyReference)
+                .NotXssString()
+                .WithErrorCode(ErrorCodes.XssCheckFailure)
+                .When(y => !string.IsNullOrEmpty(y.Uprn));
+            RuleFor(x => x.PaymentReference)
+                .NotXssString()
+                .WithErrorCode(ErrorCodes.XssCheckFailure)
+                .When(y => !string.IsNullOrEmpty(y.Uprn));
+        }
+    }
+}

--- a/Hackney.Shared.Person/Boundary/Request/Validation/UpdatePersonRequestObjectValidator.cs
+++ b/Hackney.Shared.Person/Boundary/Request/Validation/UpdatePersonRequestObjectValidator.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using Hackney.Core.Validation;
-using Hackney.Shared.Tenure.Boundary.Requests.Validation;
 using System;
 
 namespace Hackney.Shared.Person.Boundary.Request.Validation
@@ -50,7 +49,7 @@ namespace Hackney.Shared.Person.Boundary.Request.Validation
                 .NotXssString()
                 .WithErrorCode(ErrorCodes.XssCheckFailure)
                 .When(y => !string.IsNullOrEmpty(y.PlaceOfBirth));
-            RuleForEach(x => x.Tenures).SetValidator(new TenureInformationValidator());
+            RuleForEach(x => x.Tenures).SetValidator(new TenureValidator());
         }
     }
 }

--- a/Hackney.Shared.Person/Boundary/Response/PersonResponseObject.cs
+++ b/Hackney.Shared.Person/Boundary/Response/PersonResponseObject.cs
@@ -1,7 +1,6 @@
 using Hackney.Shared.Person.Domain;
 using System;
 using System.Collections.Generic;
-using Hackney.Shared.Tenure.Boundary.Response;
 
 namespace Hackney.Shared.Person.Boundary.Response
 {

--- a/Hackney.Shared.Person/Boundary/Response/TenureResponseObject.cs
+++ b/Hackney.Shared.Person/Boundary/Response/TenureResponseObject.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Hackney.Shared.Person.Boundary.Response
+{
+    public class TenureResponseObject
+    {
+        public string AssetFullAddress { get; set; }
+
+        public string AssetId { get; set; }
+
+        public string StartDate { get; set; }
+
+        public string EndDate { get; set; }
+
+        public Guid Id { get; set; }
+
+        public string Type { get; set; }
+
+        public string Uprn { get; set; }
+
+        public string PaymentReference { get; set; }
+
+        public string PropertyReference { get; set; }
+
+        public bool IsActive { get; set; }
+    }
+}

--- a/Hackney.Shared.Person/Domain/Person.cs
+++ b/Hackney.Shared.Person/Domain/Person.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Hackney.Shared.Tenure.Domain;
 using Hackney.Shared.Person.Domain;
 
 namespace Hackney.Shared.Person
@@ -20,7 +19,7 @@ namespace Hackney.Shared.Person
         public DateTime? DateOfBirth { get; set; }
         public string Reason { get; set; }
         public IEnumerable<PersonType> PersonTypes { get; set; }
-        public IEnumerable<TenureInformation> Tenures { get; set; }
+        public IEnumerable<TenureDetails> Tenures { get; set; }
         public int? VersionNumber { get; set; }
         public DateTime? LastModified { get; set; }
     }

--- a/Hackney.Shared.Person/Domain/TenureDetails.cs
+++ b/Hackney.Shared.Person/Domain/TenureDetails.cs
@@ -1,0 +1,64 @@
+﻿using Hackney.Shared.Tenure.Domain;
+using System;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace Hackney.Shared.Person.Domain
+{
+    public class TenureDetails
+    {
+        public string AssetFullAddress { get; set; }
+
+        public string AssetId { get; set; }
+
+        public string StartDate { get; set; }
+
+        public string EndDate { get; set; }
+
+        public Guid Id { get; set; }
+
+        public string Type { get; set; }
+
+        public string Uprn { get; set; }
+
+        public string PaymentReference { get; set; }
+
+        public string PropertyReference { get; set; }
+
+        [JsonIgnore]
+        public bool IsActive => TenureHelpers.IsTenureActive(EndDate);
+
+        public override bool Equals(object obj)
+        {
+            if (GetType() != obj?.GetType()) return false;
+            var otherObj = (TenureDetails)obj;
+            return otherObj != null
+                && (String.Compare(AssetFullAddress, otherObj.AssetFullAddress) == 0)
+                && (String.Compare(AssetId, otherObj.AssetId) == 0)
+                && (String.Compare(StartDate, otherObj.StartDate) == 0)
+                && (String.Compare(EndDate, otherObj.EndDate) == 0)
+                && Id.Equals(otherObj.Id)
+                && (String.Compare(Type, otherObj.Type) == 0)
+                && (String.Compare(Uprn, otherObj.Uprn) == 0)
+                && (String.Compare(PaymentReference, otherObj.PaymentReference) == 0)
+                && (String.Compare(PropertyReference, otherObj.PropertyReference) == 0);
+        }
+
+        public override int GetHashCode()
+        {
+            StringBuilder builder = new StringBuilder();
+            return builder.Append(AssetFullAddress)
+                          .Append(AssetId)
+                          .Append(StartDate)
+                          .Append(EndDate)
+                          .Append(Id.ToString())
+                          .Append(Type)
+                          .Append(Uprn)
+                          .Append(PaymentReference)
+                          .Append(PropertyReference)
+                          .Append(IsActive)
+                          .ToString()
+                          .GetHashCode();
+        }
+    }
+}

--- a/Hackney.Shared.Person/Factories/ResponseFactory.cs
+++ b/Hackney.Shared.Person/Factories/ResponseFactory.cs
@@ -1,8 +1,6 @@
 using Hackney.Shared.Person.Boundary;
 using Hackney.Shared.Person.Boundary.Response;
-using Hackney.Shared.Tenure.Boundary.Response;
-using Hackney.Shared.Tenure.Domain;
-using Hackney.Shared.Tenure.Factories;
+using Hackney.Shared.Person.Domain;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -46,17 +44,42 @@ namespace Hackney.Shared.Person.Factories
             };
         }
 
-        private static List<TenureResponseObject> SortTenures(IEnumerable<TenureInformation> tenures)
+        private static List<TenureResponseObject> SortTenures(IEnumerable<TenureDetails> tenures)
         {
             if (tenures == null) return null;
 
             var sortedTenures = tenures
                 .OrderByDescending(x => x.IsActive)
-                .ThenByDescending(x => x.TenureType.Description == "Secure")
-                .ThenByDescending(x => x.StartOfTenureDate)
+                .ThenByDescending(x => x.Type == "Secure")
+                .ThenByDescending(ParseTenureStartDate)
                 .ToList();
 
-            return sortedTenures.Select(x => x.ToResponse()).ToList();
+            return sortedTenures.Select(x => ToResponse(x)).ToList();
+        }
+
+        private static DateTime? ParseTenureStartDate(TenureDetails tenure)
+        {
+            DateTime parsedDate;
+            if (DateTime.TryParse(tenure.StartDate, out parsedDate)) return (DateTime?)parsedDate;
+
+            return null;
+        }
+
+        public static TenureResponseObject ToResponse(TenureDetails tenure)
+        {
+            return new TenureResponseObject()
+            {
+                AssetFullAddress = tenure.AssetFullAddress,
+                AssetId = tenure.AssetId,
+                EndDate = tenure.EndDate,
+                Id = tenure.Id,
+                IsActive = tenure.IsActive,
+                PaymentReference = tenure.PaymentReference,
+                PropertyReference = tenure.PropertyReference,
+                StartDate = tenure.StartDate,
+                Type = tenure.Type,
+                Uprn = tenure.Uprn
+            };
         }
 
     }

--- a/Hackney.Shared.Person/Infrastructure/PersonDbEntity.cs
+++ b/Hackney.Shared.Person/Infrastructure/PersonDbEntity.cs
@@ -1,9 +1,8 @@
 using Amazon.DynamoDBv2.DataModel;
 using Hackney.Core.DynamoDb.Converters;
+using Hackney.Shared.Person.Domain;
 using System;
 using System.Collections.Generic;
-using Hackney.Shared.Person.Domain;
-using Hackney.Shared.Tenure.Domain;
 
 namespace Hackney.Shared.Person.Infrastructure
 {
@@ -32,8 +31,8 @@ namespace Hackney.Shared.Person.Infrastructure
         [DynamoDBProperty(Converter = typeof(DynamoDbEnumListConverter<PersonType>))]
         public List<PersonType> PersonTypes { get; set; } = new List<PersonType>();
 
-        [DynamoDBProperty(Converter = typeof(DynamoDbObjectListConverter<TenureInformation>))]
-        public List<TenureInformation> Tenures { get; set; } = new List<TenureInformation>();
+        [DynamoDBProperty(Converter = typeof(DynamoDbObjectListConverter<TenureDetails>))]
+        public List<Domain.TenureDetails> Tenures { get; set; } = new List<TenureDetails>();
 
         [DynamoDBVersion]
         public int? VersionNumber { get; set; }


### PR DESCRIPTION
Re-instated tenure model within the person domain as this is distinct from the full `TenureInformation` model within the tenure domain.
Only change to that originally implemented is to rename the class to `TenureDetails` so as to avoid name clashes with the `Tenure` namespace.