### PR TITLE
Limit which Mvc packages are pulled in

### DIFF
--- a/Hackney.Shared.Person/Hackney.Shared.Person.csproj
+++ b/Hackney.Shared.Person/Hackney.Shared.Person.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Hackney.Shared.Person</PackageId>
@@ -12,14 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Hackney.Core.DynamoDb" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
-    <PackageReference Include="Hackney.Shared.Tenure" Version="0.3.0" />
+    <PackageReference Include="Hackney.Shared.Tenure" Version="0.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
-    <PackageReference Include="Hackney.Core.DynamoDb" Version="1.30.0" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Limit which Mvc packages are pulled in because including the entire Mvc 2.2 package will cause build conflicts when the package is used within a .net core 3.1 web api application.