### PR TITLE
Add branch names to NuGet package versions

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,15 +2,15 @@ assembly-versioning-scheme: MajorMinorPatch
 mode: Mainline
 branches:
   master:
-    regex: ^master$|^main$
+    regex: ^master$|^main$|^release$
     increment: Minor
     is-source-branch-for: ['feature']
     is-mainline: true
   feature:
     regex: feature[/-]
-    tag: preview
+    tag: "feat-{BranchName}"
     increment: Minor
-    source-branches: ['master', 'main']
+    source-branches: ['master', 'main', 'release']
 ignore:
   sha: []
 merge-message-formats: {}

--- a/README.md
+++ b/README.md
@@ -1,19 +1,28 @@
 # Hackney.Shared.Person
 At Hackney, we have created NuGet Packages to prevent the duplication of common code when implementing our APIs.
-This NuGet package will store the shared code related to a person that can then be used in the relevant projects. 
+This NuGet package will store the shared code related to the person domain that can then be used in the relevant projects.
 
-#### GitHub Actions Pipeline - Versioning
+## Using the package
+For full details on how to use the package(s) within this repository please read 
+[this wiki page](https://github.com/LBHackney-IT/lbh-core/wiki/Using-the-package(s)-from-the-Hackney.Core-repository).
+
+## Contributing
+
+### Automated Versioning
 The pipeline automatically updates the package version number.
 
-Version numbers use the following format:
-
-Any specific version number follows the form Major.Minor.Patch[-Suffix], where the components have the following meanings:
+Any specific version number follows the form `Major.Minor.Patch[-Suffix]`, where the components have the following meanings:
 
 * *Major*: Breaking changes
 * *Minor*: New features, but backward compatible
 * *Patch*: Backwards compatible bug fixes only
 * *Suffix (optional)*: a hyphen followed by a string denoting a pre-release version
 
-## Using the package
-For full details on how to use the package(s) within this repository please read 
-[this wiki page](https://github.com/LBHackney-IT/lbh-core/wiki/Using-the-package(s)-from-the-Hackney.Core-repository).
+## Branching Strategy
+
+In order for the pipeline to be able to run automated tests and create preview versions of packages, you must name your branch correctly.
+
+**Name your branch following the convention of `feature/<some-feature>`.** This will allow the pipeline to work correctly. 
+If all tests pass, a new version of your package will be publised on every commit. You can see published versions of packages [here](https://github.com/orgs/LBHackney-IT/packages?repo_name=person-shared).
+
+All preview versions of packages will have the suffix **`-feat-<branch-name>-<number>`**

--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ Any specific version number follows the form `Major.Minor.Patch[-Suffix]`, where
 * *Patch*: Backwards compatible bug fixes only
 * *Suffix (optional)*: a hyphen followed by a string denoting a pre-release version
 
-## Branching Strategy
+### Branching Strategy
 
 In order for the pipeline to be able to run automated tests and create preview versions of packages, you must name your branch correctly.
 
 **Name your branch following the convention of `feature/<some-feature>`.** This will allow the pipeline to work correctly. 
-If all tests pass, a new version of your package will be publised on every commit. You can see published versions of packages [here](https://github.com/orgs/LBHackney-IT/packages?repo_name=person-shared).
+If all tests pass, a new version of your package will be publised on every commit. You can see published versions of packages [here](https://github.com/orgs/LBHackney-IT/packages?repo_name=housing-search-shared).
 
-All preview versions of packages will have the suffix **`-feat-<branch-name>-<number>`**
+All preview versions of packages will have the suffix **`-feat-<branch-name>-<number>`**.
+
+This branch name in the package version has a character limit of **12 characters**, so try to name your branch accordingly, otherwise it will be cut off.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Any specific version number follows the form `Major.Minor.Patch[-Suffix]`, where
 In order for the pipeline to be able to run automated tests and create preview versions of packages, you must name your branch correctly.
 
 **Name your branch following the convention of `feature/<some-feature>`.** This will allow the pipeline to work correctly. 
-If all tests pass, a new version of your package will be publised on every commit. You can see published versions of packages [here](https://github.com/orgs/LBHackney-IT/packages?repo_name=housing-search-shared).
+If all tests pass, a new version of your package will be publised on every commit. You can see published versions of packages [here](https://github.com/orgs/LBHackney-IT/packages?repo_name=person-shared).
 
 All preview versions of packages will have the suffix **`-feat-<branch-name>-<number>`**.
 


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-2231

## Describe this PR

### *What is the problem we're trying to solve*

The pipeline currently fails when multiple people are working on the same package concurrently due to a conflict (a version of the package has been published already). This can be rectified by adding branch names to preview versions of NuGet packages.

### *What changes have we introduced*

- Updated the gitversion config to use branch names in versions
- Updated the readme with better contribution guidelines

#### _Checklist_

- [x] Added comments to the README or updated relevant documentation, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
