### PR TITLE
Feature/nullable title and dob

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/gitguardian/ggshield
+    rev: v1.13.3
+    hooks:
+      - id: ggshield
+        language_version: python3
+        stages: [commit]

--- a/Hackney.Shared.Person.Tests/Boundary/Validation/CreatePersonRequestObjectValidatorTests.cs
+++ b/Hackney.Shared.Person.Tests/Boundary/Validation/CreatePersonRequestObjectValidatorTests.cs
@@ -48,12 +48,29 @@ namespace Hackney.Shared.Person.Tests.Boundary.Request.Validation
             result.ShouldHaveValidationErrorFor(x => x.Title);
         }
 
-        [Fact]
-        public void TitleShouldNotErrorWithNullValue()
+        [Theory]
+        [InlineData(PersonType.HousingOfficer)]
+        [InlineData(PersonType.HousingAreaManager)]
+        public void TitleShouldNotErrorWithNullValueIfPersonTypeIsHOorHAM(PersonType personType)
         {
-            var model = new CreatePersonRequestObject() { Title = null };
+            var personTypeList = new List<PersonType>() { personType };
+            var model = new CreatePersonRequestObject() { Title = null, PersonTypes = personTypeList};
             var result = _sut.TestValidate(model);
             result.ShouldNotHaveValidationErrorFor(x => x.Title);
+        }
+
+        [Theory]
+        [InlineData(PersonType.Freeholder)]
+        [InlineData(PersonType.Occupant)]
+        [InlineData(PersonType.Tenant)]
+        [InlineData(PersonType.Leaseholder)]
+        [InlineData(PersonType.HouseholdMember)]
+        public void TitleShouldErrorWithNullValueIfPersonTypeIsNotHOorHAM(PersonType personType)
+        {
+            var personTypeList = new List<PersonType>() { personType };
+            var model = new CreatePersonRequestObject() { Title = null, PersonTypes = personTypeList };
+            var result = _sut.TestValidate(model);
+            result.ShouldHaveValidationErrorFor(x => x.Title);
         }
 
         [Theory]
@@ -219,12 +236,29 @@ namespace Hackney.Shared.Person.Tests.Boundary.Request.Validation
                   .WithErrorCode(ErrorCodes.DoBInvalid);
         }
 
-        [Fact]
-        public void DateOfBirthShouldNotErrorWithNullValue()
+        [Theory]
+        [InlineData(PersonType.HousingOfficer)]
+        [InlineData(PersonType.HousingAreaManager)]
+        public void DateOfBirthShouldNotErrorWithNullIfPersonTypeIsHOOrHAM(PersonType personType)
         {
-            var model = new CreatePersonRequestObject() { DateOfBirth = null };
+            var listOfPersonType = new List<PersonType>() { personType };
+            var model = new CreatePersonRequestObject() { DateOfBirth = null, PersonTypes = listOfPersonType };
             var result = _sut.TestValidate(model);
             result.ShouldNotHaveValidationErrorFor(x => x.DateOfBirth);
+        }
+
+        [Theory]
+        [InlineData(PersonType.Freeholder)]
+        [InlineData(PersonType.Occupant)]
+        [InlineData(PersonType.Tenant)]
+        [InlineData(PersonType.Leaseholder)]
+        [InlineData(PersonType.HouseholdMember)]
+        public void DateOfBirthShouldErrorWithNullValueIfPersonTypeIsNotHOorHAM(PersonType personType)
+        {
+            var personTypeList = new List<PersonType>() { personType };
+            var model = new CreatePersonRequestObject() { DateOfBirth = null, PersonTypes = personTypeList };
+            var result = _sut.TestValidate(model);
+            result.ShouldHaveValidationErrorFor(x => x.DateOfBirth);
         }
 
         [Fact]

--- a/Hackney.Shared.Person.Tests/Boundary/Validation/CreatePersonRequestObjectValidatorTests.cs
+++ b/Hackney.Shared.Person.Tests/Boundary/Validation/CreatePersonRequestObjectValidatorTests.cs
@@ -48,6 +48,14 @@ namespace Hackney.Shared.Person.Tests.Boundary.Request.Validation
             result.ShouldHaveValidationErrorFor(x => x.Title);
         }
 
+        [Fact]
+        public void TitleShouldNotErrorWithNullValue()
+        {
+            var model = new CreatePersonRequestObject() { Title = null };
+            var result = _sut.TestValidate(model);
+            result.ShouldNotHaveValidationErrorFor(x => x.Title);
+        }
+
         [Theory]
         [MemberData(nameof(Titles))]
         [InlineData(null)]
@@ -209,6 +217,14 @@ namespace Hackney.Shared.Person.Tests.Boundary.Request.Validation
             var result = _sut.TestValidate(model);
             result.ShouldHaveValidationErrorFor(x => x.DateOfBirth)
                   .WithErrorCode(ErrorCodes.DoBInvalid);
+        }
+
+        [Fact]
+        public void DateOfBirthShouldNotErrorWithNullValue()
+        {
+            var model = new CreatePersonRequestObject() { DateOfBirth = null };
+            var result = _sut.TestValidate(model);
+            result.ShouldNotHaveValidationErrorFor(x => x.DateOfBirth);
         }
 
         [Fact]

--- a/Hackney.Shared.Person/Boundary/Request/Validation/CreatePersonRequestObjectValidator.cs
+++ b/Hackney.Shared.Person/Boundary/Request/Validation/CreatePersonRequestObjectValidator.cs
@@ -1,6 +1,8 @@
 using FluentValidation;
 using Hackney.Core.Validation;
+using Hackney.Shared.Person.Domain;
 using System;
+using System.Linq;
 
 namespace Hackney.Shared.Person.Boundary.Request.Validation
 {
@@ -10,10 +12,19 @@ namespace Hackney.Shared.Person.Boundary.Request.Validation
         {
             RuleFor(x => x.Title).IsInEnum();
 
+            //Title should be nullable for HousingOfficer and HousingAreaManager PersonTypes. 
+            RuleFor(x => x.Title).NotNull().When(x => false == x.PersonTypes.Contains(PersonType.HousingOfficer))
+                                           .When(x => false == x.PersonTypes.Contains(PersonType.HousingAreaManager));
+
+
             RuleFor(x => x.DateOfBirth).NotEqual(default(DateTime))
                                        .WithErrorCode(ErrorCodes.DoBInvalid);
             RuleFor(x => x.DateOfBirth).LessThan(DateTime.UtcNow)
                                        .WithErrorCode(ErrorCodes.DoBInFuture);
+
+            //DOB should be nullable for HousingOfficer and HousingAreaManager PersonTypes
+            RuleFor(x => x.DateOfBirth).NotNull().When(x => false == x.PersonTypes.Contains(PersonType.HousingOfficer))
+                                                 .When(x => false == x.PersonTypes.Contains(PersonType.HousingAreaManager));
 
             RuleFor(x => x.FirstName).NotNull()
                                      .NotEmpty()

--- a/Hackney.Shared.Person/Boundary/Request/Validation/CreatePersonRequestObjectValidator.cs
+++ b/Hackney.Shared.Person/Boundary/Request/Validation/CreatePersonRequestObjectValidator.cs
@@ -8,11 +8,9 @@ namespace Hackney.Shared.Person.Boundary.Request.Validation
     {
         public CreatePersonRequestObjectValidator()
         {
-            RuleFor(x => x.Title).NotNull()
-                                 .IsInEnum();
+            RuleFor(x => x.Title).IsInEnum();
 
-            RuleFor(x => x.DateOfBirth).NotNull()
-                                       .NotEqual(default(DateTime))
+            RuleFor(x => x.DateOfBirth).NotEqual(default(DateTime))
                                        .WithErrorCode(ErrorCodes.DoBInvalid);
             RuleFor(x => x.DateOfBirth).LessThan(DateTime.UtcNow)
                                        .WithErrorCode(ErrorCodes.DoBInFuture);

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+.PHONY: setup
+setup:
+	docker-compose build
+
+.PHONY: build
+build:
+	docker-compose build hackney-shared-person-test
+
+.PHONY: serve
+serve:
+	docker-compose build hackney-shared-person-test && docker-compose up hackney-shared-person-test
+
+.PHONY: shell
+shell:
+	docker-compose run hackney-shared-person-test bash
+
+.PHONY: test
+test:
+	docker-compose up test-database & docker-compose build hackney-shared-person-test && docker-compose up hackney-shared-person-test
+
+.PHONY: lint
+lint:
+	-dotnet tool install -g dotnet-format
+	dotnet tool update -g dotnet-format
+	dotnet format
+
+.PHONY: restart-db
+restart-db:
+	docker stop $$(docker ps -q --filter ancestor=test-database -a)
+	-docker rm $$(docker ps -q --filter ancestor=test-database -a)
+	docker rmi test-database
+	docker-compose up -d test-database


### PR DESCRIPTION
Title and DOB can be Nullable only for Housing Officer and Housing Area Manager Person Types. All other person types currently require a DOB and Title to be provided. This is because there is no current use case to hold Title and DOB data for our Staff. 